### PR TITLE
adding batches

### DIFF
--- a/iris.py
+++ b/iris.py
@@ -16,7 +16,7 @@ encoder = preprocessing.OneHotEncoder()
 y = encoder.fit_transform(y.reshape((-1, 1))).todense()
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33)
 N = Network(
-    [4, 3], learning_rate=0.25, n_epochs=1000, cost_fun="cross-entropy", batch_size=10
+    [4, 3], learning_rate=0.25, n_epochs=5, batch_size=10
 )  # best without hidden layers - iris dataset is too small
 N.train_batches(X_train, y_train)
 pred = N.fit(X_test)

--- a/network.py
+++ b/network.py
@@ -19,31 +19,31 @@ class Layer:
         self.n_input = n_input
         self.n_output = n_output
         self.momentum = np.zeros(self.weights.shape)
-        self.momentum_bias = np.zeros(self.bias.shape)
 
-    def update_weights(self, W, learning_rate, momentum_rate):
+    def update_weights(self, W, learning_rate, momentum_rate, batch_size=1):
         change = (
-            learning_rate * np.array(W).reshape(self.weights.shape)
+            (learning_rate / batch_size) * np.array(W).reshape(self.weights.shape)
             - momentum_rate * self.momentum
         )
         self.weights = self.weights - change
         self.momentum = change
 
-    def update_bias(self, b, learning_rate, momentum_rate):
+    def update_bias(self, b, learning_rate, momentum_rate, batch_size=1):
         change = (
-            learning_rate * np.array(b).reshape(self.bias.shape)
-            - momentum_rate * self.momentum_bias
+            (learning_rate / batch_size) * np.array(b).reshape(self.bias.shape)
+            # I removed momentum in bias (it's not necessary I think)
         )
         self.bias = self.bias - change
-        self.momentum_bias = change
 
     def activation(self, x):
         if self.activation_type == "sigmoid":
-            return 1 / (1 + np.exp(-x))
+            return 1.0 / (1.0 + np.exp(-x))
         if self.activation_type == "tanh":
             return np.tanh(x)
         if self.activation_type == "relu":
             return np.maximum(0.0, x)
+        if self.activation_type == "linear":
+            return x
 
     def fit(self, inputs: np.array):
         """Returns output (sigma(Wx+b))"""
@@ -71,22 +71,36 @@ class Network:
         n_epochs=10,
         cost_fun="quadratic",
         batch_size=1,
+        regression=False,
     ):
         self.cost_fun = cost_fun
         self.learing_rate = learning_rate
         self.momentum_rate = momentum_rate
         self.n_epochs = n_epochs
         self.batch_size = batch_size
+        self.regression = regression
         layers_kwargs = {"activation_type": activation_type, "init_sigma": init_sigma}
         try:
             if len(layers) < 2:
                 raise ValueError("Network must have at least 2 layers")
         except TypeError:  # if len(layers) throws error (for example user specified an integer)
             raise TypeError("Layers must be a list of number of neurons in each layer")
-        self.layers = [
-            Layer(layers[i], layers[i + 1], **layers_kwargs)
-            for i in range(len(layers) - 1)
-        ]
+        if self.regression:
+            if layers[-1] != 1:
+                raise ValueError("In regression, output layer is 1-dimensional!")
+            if self.cost_fun != "quadratic":
+                raise ValueError("In regression, we only use quadratic cost function!")
+            self.layers = [
+                Layer(layers[i], layers[i + 1], **layers_kwargs)
+                for i in range(len(layers) - 2)
+            ]
+            self.layers.append(Layer(layers[-2], layers[-1], "linear", init_sigma))
+        else:
+            self.layers = [
+                Layer(layers[i], layers[i + 1], **layers_kwargs)
+                for i in range(len(layers) - 1)
+            ]
+
         if (self.cost_fun in ["cross-entropy", "hellinger"]) and (activation_type != "sigmoid"):
             raise ValueError("This activation does not support the desired cost function")
 
@@ -162,64 +176,89 @@ class Network:
             )  # if y is an one-dimensional vector - make it a column vector (matrix)
         if X.shape[0] != Y.shape[0]:
             raise ValueError("X and y have different row numbers")
-        n_rows = X.shape[0]
-        train_data = [(x, y) for (x, y) in zip(X, Y)]
+        n_rows = X.shape[0]  # number of training observations
+        train_data = [(x, y) for (x, y) in zip(X, Y)]  # list of tuples (x,y) with the training observations
         for _ in range(self.n_epochs):
+            # randomly shuffling data to choose batches randomly
             np.random.shuffle(train_data)
+            # creating list of training batches
             batches = [train_data[i:i + self.batch_size] for i in range(0, n_rows, self.batch_size)]
+
+            # now, we want to iterate over batches and update the weights and biases after
+            # calculating gradients of cost function for every observation in particular batch
             for batch in batches:
-                for n, layer in reversed(list(enumerate(self.layers))):
-                    if n == len(self.layers) - 1:  # if this is output layer
-                        deltas = np.zeros((layer.n_output, 1))
-                        for x, y in batch:
-                            x = x.reshape((1, -1))  # row vector
-                            y = y.reshape((1, -1))  # row vector
-                            pred = self.fit(x)
-                            deriv = self.activation_derivative(layer, pred)
+                change_bias = [np.zeros(layer.bias.shape) for layer in self.layers]
+                change_weights = [np.zeros(layer.weights.shape) for layer in self.layers]
+                for x, y in batch:
+                    x = x.reshape((-1, 1))  # row vector
+                    y = y.reshape((-1, 1))  # row vector
 
-                            if self.cost_fun == "quadratic":
-                                cost_deriv = pred - y
-                            elif self.cost_fun == "cross-entropy":
-                                # only with sigmoid activation function
-                                # not sure if it's ok
-                                cost_deriv = pred - y
-                                deriv = np.array([1 for _ in range(len(deriv))])
-                            elif self.cost_fun == "hellinger":
-                                # only with positive activation functions
-                                cost_deriv = (np.sqrt(pred) - np.sqrt(y)) / (
-                                        np.sqrt(2) * np.sqrt(pred)
-                                )
-                            else:
-                                raise ValueError("No such cost function")
+                    # In this part we calculate the gradient of the cost function
+                    change_bias_xy = [np.zeros(layer.bias.shape) for layer in self.layers]
+                    change_weights_xy = [np.zeros(layer.weights.shape) for layer in self.layers]
+                    # #############################################
+                    # TO DO: ten fragment można zamknąć w funkcji
+                    # (odpowiednik fit, ale musimy zachować zs i activations)
+                    # activation
+                    a = x
+                    # list of activations
+                    activations = [x]
+                    # weighted inputs
+                    zs = []
+                    for layer in self.layers:
+                        z = layer.lin_comb(a)
+                        zs.append(z)
+                        a = layer.activation(z)
+                        activations.append(a)
+                    print(activations)
+                    # backward - output layer
+                    # we start by calculating delta in the output layer
+                    deriv = self.activation_derivative(self.layers[-1], zs[-1])
+                    pred = activations[-1]
 
-                            delta = deriv.reshape((-1, 1)) * cost_deriv.reshape((-1, 1))
-                            deltas += delta
-
-                        deltas /= self.batch_size
-                        layer.set_delta(deltas)
-
-                    else:  # if this is a hidden layer
-                        # using delta and weights from n+1
-                        delta = np.matmul(prev_weights.transpose(), delta).reshape(
-                            -1, 1
+                    if self.cost_fun == "quadratic":
+                        cost_deriv = pred - y
+                    elif self.cost_fun == "cross-entropy":
+                        # only with sigmoid activation function
+                        # not sure if it's ok
+                        cost_deriv = pred - y
+                        deriv = np.array([1 for _ in range(len(deriv))])
+                    elif self.cost_fun == "hellinger":
+                        # only with positive activation functions
+                        cost_deriv = (np.sqrt(pred) - np.sqrt(y)) / (
+                                np.sqrt(2) * np.sqrt(pred)
                         )
-                        layer.set_delta(delta)
-                    prev_weights = (
-                        layer.weights
-                    )  # we calculate delta in n layer using weights from n+1
+                    else:
+                        raise ValueError("No such cost function")
+                    # TO DO
+                    # tutaj można set_delta użyć jakoś
+                    delta = cost_deriv * deriv
+                    change_bias_xy[-1] = delta
+                    change_weights_xy[-1] = np.dot(delta, activations[-2].T)
 
-                    # going front to back - updating weights using deltas
-                for layer in self.layers:
-                    y = layer.fit(x)
+                    # backward - remaining layers
+                    for l in range(2, len(self.layers)):
+                        z = zs[-l]
+                        deriv = self.activation_derivative(self.layers[-l], z)
+                        # TO DO
+                        # tutaj można set_delta użyć jakoś
+                        delta = np.dot(self.layers[-l+1].weights.transpose(), delta) * deriv
+                        change_bias_xy[-l] = delta
+                        change_weights_xy[-l] = np.dot(delta, activations[-l-1].T)
+
+                    change_bias = [c_b+c_b_xy for c_b, c_b_xy in zip(change_bias, change_bias_xy)]
+                    change_weights = [c_w+c_w_xy for c_w, c_w_xy in zip(change_weights, change_weights_xy)]
+
+                for i, layer in enumerate(self.layers):
                     layer.update_weights(
-                        np.matmul(layer.delta, x.reshape((1, -1))),
+                        change_weights[i],
                         self.learing_rate,
                         self.momentum_rate,
+                        self.batch_size
                     )
                     layer.update_bias(
-                        layer.delta, self.learing_rate, self.momentum_rate
+                        change_bias[i], self.learing_rate, self.momentum_rate, self.batch_size
                     )
-                    x = y  # output becomes input for next layer
 
     def activation_derivative(self, layer, pred):
         if layer.activation_type == "sigmoid":
@@ -228,9 +267,11 @@ class Network:
             deriv = 1 - pred ** 2
         elif layer.activation_type == "relu":
             deriv = pred > 0
+        elif layer.activation_type == "linear":
+            deriv = np.ones(pred.shape, dtype=np.float64)
         else:
             raise ValueError("No such activation function")
-        return deriv
+        return np.array([deriv]).reshape(-1, 1)
 
     def fit(self, X):
         def fit_one(x):

--- a/regression.py
+++ b/regression.py
@@ -1,0 +1,40 @@
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from sklearn import preprocessing
+from sklearn.metrics import r2_score
+
+from network import Network
+
+PATH = os.path.join("data", "regression")
+datasets = ["data.activation", "data.cube"]
+
+sizes = [100, 500, 1000]
+N = 500
+
+np.random.seed(15)
+fig, axs = plt.subplots(1, 4, figsize=(16, 10))
+for j, size in enumerate(sizes):
+    training_data = pd.read_csv(os.path.join(PATH, f"{datasets[0]}.train.{size}.csv"))
+    test_data = pd.read_csv(os.path.join(PATH, f"{datasets[0]}.test.{size}.csv"))
+    MLP = Network([1, 16, 8, 1], regression=True, n_epochs=250, batch_size=10, activation_type="tanh")
+    MLP.train_batches(training_data[["x"]].to_numpy(), training_data[["y"]].to_numpy())
+    y_pred = MLP.fit(test_data[["x"]].to_numpy())
+    print(r2_score(test_data[["y"]], y_pred))
+    # axs[0][j].scatter(mesh[:, 0], mesh[:, 1], s=0.5, c=pred_mesh)
+    axs[j].scatter(test_data.x, test_data.y)
+    axs[j].scatter(test_data.x, y_pred)
+
+# for j, size in enumerate(sizes):
+#     training_data = pd.read_csv(os.path.join(PATH, f"{datasets[1]}.train.{size}.csv"))
+#     test_data = pd.read_csv(os.path.join(PATH, f"{datasets[1]}.test.{size}.csv"))
+#     MLP = Network([1, 2, 1], regression=True, batch_size=10, n_epochs=50)
+#     MLP.train_batches(training_data[["x"]].to_numpy(), training_data[["y"]].to_numpy())
+#     y_pred = MLP.fit(test_data[["x"]].to_numpy())
+#     print(r2_score(test_data[["y"]], y_pred))
+#     axs[1][j].scatter(test_data.x, test_data.y)
+#     axs[1][j].scatter(test_data.x, y_pred)
+
+plt.show()


### PR DESCRIPTION
Ten PR ma na celu dodanie podziału na batches w trakcie uczenia modelu. 
Zmiany w kodzie:

1. _iris.py_ - tylko mała zabawa z parametrami, dodałem uczenie za pomocą nowej funkcji _train_batches()_

 

2. _network.py_ - w konstruktorze pojawił się nowy atrybut batch_size, dodałem również obsługę wyjątku, gdy ktoś chce zastosować inną funkcję aktywacji przy funkcji kosztu, która działa tylko na przedziale [0,1] dobrze (czyli ReLU i arctg odpadają)
- żeby nie ingerować w poprzednią metodę uczącą, dodałem nową metodę _train_batches()_, wykorzystuje nowy atrybut _batch_size_. Wygląda ona bardzo podobnie, dodane jest tylko uśrednianie oraz shufflowanie i podział zbioru uczącego na batche.

Ogólnie to powinno być chyba tak, że dla batch_size = 1 powinno być to samo co w poprzedniej funkcji _train()_, ale okazuje się, że gorzej się uczy w tej nowej metodzie przy takim parametrze. Nie wiem, dlaczego tak jest xD Możliwe, że nadal jest jakiś błąd w implementacji tej nowej metody, ale np. Iris na batch_size=10 uzyskuje 96% skuteczności, więc sam nie wiem. 

Proszę o recenzję 😸 
