### PR TITLE
WIP: plotting the results, but still with rescaling

### DIFF
--- a/regression.py
+++ b/regression.py
@@ -13,20 +13,20 @@ sizes = [100, 500, 1000, 10000]
 N = 100
 fig, axs = plt.subplots(2, len(sizes), figsize=(12, 8))
 for j, size in enumerate(sizes):
-    train = rescale_df(pd.read_csv(os.path.join(PATH, f"{datasets[0]}.train.{size}.csv")))
-    test = rescale_df(pd.read_csv(os.path.join(PATH, f"{datasets[0]}.test.{size}.csv")))
+    train = (pd.read_csv(os.path.join(PATH, f"{datasets[0]}.train.{size}.csv")))
+    test = (pd.read_csv(os.path.join(PATH, f"{datasets[0]}.test.{size}.csv")))
     MLP = Network(
         [1, 2, 2, 1],
         regression=True,
         n_epochs=10000,
-        batch_size=size//10,
+        batch_size=size//100,
         activation_type="sigmoid",
         learning_rate=0.01,
         momentum_rate=0.01,
         print_progress=True,
     )
     MLP.train(train[["x"]].to_numpy(), train[["y"]].to_numpy())
-    prediction = MLP.fit(test[['x']].to_numpy())
+    prediction = MLP.fit(test[['x']].to_numpy(), predict=True)
 
     p= axs[0][j].scatter(test[["x"]], test[["y"]], c="red", )
     r=axs[0][j].scatter(
@@ -36,20 +36,20 @@ for j, size in enumerate(sizes):
     axs[0][j].legend([p,r,q], ['Test data', 'Training data', 'Prediction data'])
 
 for j, size in enumerate(sizes):
-    train = rescale_df(pd.read_csv(os.path.join(PATH, f"{datasets[1]}.train.{size}.csv")))
-    test = rescale_df(pd.read_csv(os.path.join(PATH, f"{datasets[1]}.test.{size}.csv")))
+    train = (pd.read_csv(os.path.join(PATH, f"{datasets[1]}.train.{size}.csv")))
+    test = (pd.read_csv(os.path.join(PATH, f"{datasets[1]}.test.{size}.csv")))
     MLP = Network(
-        [1, 2, 2, 1],
+        [1, 3, 3, 1],
         regression=True,
         n_epochs=10000,
-        batch_size=size//10,
+        batch_size=size//100,
         activation_type="sigmoid",
         learning_rate=0.01,
         momentum_rate=0.01,
         print_progress=True,
     )
     MLP.train(train[["x"]].to_numpy(), train[["y"]].to_numpy())
-    prediction = MLP.fit(test[['x']].to_numpy())
+    prediction = MLP.fit(test[['x']].to_numpy(), predict=True)
 
     p=axs[1][j].scatter(test[["x"]], test[["y"]], c="red")
     r=axs[1][j].scatter(


### PR DESCRIPTION
Pull request do zmergowania po skonczeniu #13. Wtedy też trzeba usunąć funkcję `rescale_df`. Rysuję wyniki regresji. Można używać do sprawdzania czy działa skalowanie przy robieniu #13.
Closes #2 